### PR TITLE
1.3.1 - fix #4: copy link text and location copies pageUrl

### DIFF
--- a/link-text-location-copier/linktextlocationcopier.js
+++ b/link-text-location-copier/linktextlocationcopier.js
@@ -75,7 +75,7 @@ browser.contextMenus.onClicked.addListener(function(info, tab) {
       clickedItemName = info.menuItemId.substring(info.menuItemId.indexOf('-') + 1);
 
   if (info.menuItemId.indexOf('link-') === 0) {
-    link = info.pageUrl;
+    link = info.linkUrl;
     text = info.linkText;
   } else if (info.menuItemId.indexOf('page-') === 0) {
     link = tab.url;

--- a/link-text-location-copier/manifest.json
+++ b/link-text-location-copier/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "Link Text and Location Copier",
     "description": "__MSG_extensionDescription__",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "homepage_url": "https://github.com/evilnickname/link-text-location-copier",
     "default_locale": "en",
 


### PR DESCRIPTION
Fixes #4. Add-on submitted for review.